### PR TITLE
unpin markup-safe

### DIFF
--- a/requirements-latest.txt
+++ b/requirements-latest.txt
@@ -31,7 +31,8 @@ jinja2_highlight>=0.6.1
 jinja2>=2.10.1
 lmdb>=1.1.1
 # ImportError: cannot import name 'soft_unicode' from 'markupsafe'
-MarkupSafe>=1.1.1,<2
+# MarkupSafe>=1.1.1,<2
+mistune>=0.8.4
 mistune>=0.8.4
 morphys>=1.0
 netaddr>=0.8.0

--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -30,7 +30,7 @@ jinja2_highlight>=0.6.1
 jinja2>=2.10.1
 lmdb>=1.1.1
 # ImportError: cannot import name 'soft_unicode' from 'markupsafe'
-MarkupSafe>=1.1.1,<2
+# MarkupSafe>=1.1.1,<2
 mistune>=0.8.4
 morphys>=1.0
 netaddr>=0.8.0

--- a/requirements-pinned.txt
+++ b/requirements-pinned.txt
@@ -59,7 +59,7 @@ jinja2-time==0.2.0
 jsonschema==4.9.0
 lmdb==1.3.0
 lru-dict==1.1.8
-MarkupSafe==1.1.1
+# MarkupSafe==1.1.1
 mistune==2.0.4
 mnemonic==0.20
 morphys==1.0


### PR DESCRIPTION
werkzeug CVE-2023-25577:
crossbar 22.7.1 depends on MarkupSafe<2 and >=1.1.1 werkzeug 2.2.3 depends on MarkupSafe>=2.1.1
unpin markupsafe because werkzeug will install it